### PR TITLE
chore: only publish required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,10 @@
     "sinon-chai": "^2.8.0",
     "supertest": "^2.0.1",
     "typescript": "^2.5"
-  }
+  },
+  "files": [
+    "lib",
+    "types/index.d.ts",
+    "types/alexa.d.ts"
+  ]
 }


### PR DESCRIPTION
All the other stuff is just hogging what gets published in the tarball to NPM and has no reason to be there